### PR TITLE
[feat] CBT연습, 실전시험1/2회 안내 페이지에서 시험지까지 가는 로직 구현

### DIFF
--- a/src/main/java/com/tive/controller/IndexController.java
+++ b/src/main/java/com/tive/controller/IndexController.java
@@ -1,6 +1,8 @@
 package com.tive.controller;
 
+import com.tive.dto.ExamDTO;
 import com.tive.dto.NoticeDTO;
+import com.tive.service.ExamService;
 import com.tive.service.NoticeService;
 import com.tive.service.UserDetailService;
 import com.tive.service.UserService;
@@ -22,8 +24,9 @@ import java.util.List;
 public class IndexController {
 
     private final NoticeService noticeService;
-    private final UserDetailService userDetailService;
     private final UserService userService;
+
+    private final ExamService examService;
 
     @GetMapping("/index")
     public String main2(Model model, Principal principal){
@@ -48,9 +51,9 @@ public class IndexController {
         return "index";
     }
 
-    @GetMapping("/playTest/{examKind}")
+    @GetMapping("/playTest/{eid}")
     public String playTest(
-            @PathVariable String examKind
+            @PathVariable long eid
             , Model model
             , Principal principal
     ){
@@ -67,16 +70,16 @@ public class IndexController {
             log.info("Principal is null or principal.getName() is null");
         }
 
-        model.addAttribute("examKind", examKind);
+        model.addAttribute("eid", eid);
         model.addAttribute("view", "info/play_test");
 
         return "index";
     }
 
 
-    @GetMapping("/warnInfo/{examKind}")
+    @GetMapping("/warnInfo/{eid}")
     public String warnInfo(
-            @PathVariable String examKind
+            @PathVariable int eid
             , Model model
             , Principal principal
     ){
@@ -91,7 +94,7 @@ public class IndexController {
         } else { //아니면 로그값 출력
             log.info("Principal is null or principal.getName() is null");
         }
-        model.addAttribute("examKind", examKind);
+        model.addAttribute("examKind", eid);
         model.addAttribute("view", "info/warn_info");
 
         return "index";
@@ -115,6 +118,7 @@ public class IndexController {
             log.info("Principal is null or principal.getName() is null");
         }
 
+        model.addAttribute("schoolLevel", schoolLevel);
         model.addAttribute("view", "info/cbt_test");
         return "index";
     }
@@ -122,19 +126,41 @@ public class IndexController {
     /** 응시페이지 */
     @GetMapping("/testgogo/{examKind}")
     public String testGogo(
-            @PathVariable String examKind
+            @PathVariable int examKind
             , Model model
             , Principal principal
     ){
 
-        //현재 세션으로 유저 이름 가져오기
+        //현재 세션으로 유저 이름, 학교급 가져오기
         String useremail = "";
         String username = "";
+        String userSL = "";
 
         if (principal != null && principal.getName() != null){ //로그인 한 경우에만 받아옴
             useremail = principal.getName();
-            username = userService.getUserInfo(useremail).getName();
+            username = userService.getUserInfo(useremail).getName(); // 유저 이름
+            userSL = userService.getUserInfo(useremail).getSchoolLevel(); // 학교급
             model.addAttribute("username",username);
+            model.addAttribute("userSL", userSL);
+
+            //각 과목 eid 가져오기
+            ExamDTO korean, math, english, society, science;
+
+            korean = examService.findExamInfo(userSL,"국어",examKind);
+            math = examService.findExamInfo(userSL,"수학",examKind);
+            english = examService.findExamInfo(userSL,"영어",examKind);
+
+            model.addAttribute("korean", korean);
+            model.addAttribute("math",math);
+            model.addAttribute("english",english);
+
+            if (!userSL.equals("HL")){ //고등학생이 아니면 사회, 과학도 받음
+                society = examService.findExamInfo(userSL,"사회",examKind);
+                science = examService.findExamInfo(userSL,"과학",examKind);
+                model.addAttribute("society",society);
+                model.addAttribute("science",science);
+            }
+
         } else { //아니면 로그값 출력
             log.info("Principal is null or principal.getName() is null");
         }

--- a/src/main/java/com/tive/repository/examitem/ExamItemQueryDSL.java
+++ b/src/main/java/com/tive/repository/examitem/ExamItemQueryDSL.java
@@ -9,4 +9,6 @@ public interface ExamItemQueryDSL {
     List<ExamDTO> findExamList();
 
     List<QuestionDTO> findExam(Long eid);
+
+    ExamDTO findExamInfo(String userSL, String subject, int examKind);
 }

--- a/src/main/java/com/tive/repository/examitem/ExamItemQueryDSLImpl.java
+++ b/src/main/java/com/tive/repository/examitem/ExamItemQueryDSLImpl.java
@@ -2,6 +2,7 @@ package com.tive.repository.examitem;
 
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tive.domain.SchoolLV;
 import com.tive.dto.ExamDTO;
 import com.tive.dto.QuestionDTO;
 import lombok.RequiredArgsConstructor;
@@ -49,6 +50,29 @@ public class ExamItemQueryDSLImpl implements ExamItemQueryDSL {
                 .where(examItem.eid.eq(eid))
                 .fetch();
         return list;
+    }
+
+    @Override
+    public ExamDTO findExamInfo(String userSL, String subject, int examKind) {
+        ExamDTO dto = queryFactory.select(Projections.fields(ExamDTO.class
+                , examItem.eid
+                , examItem.examName
+                , examItem.schoolLevel
+                , examItem.subject
+                , examItem.round
+                , examItem.itemCount
+                , examItem.createDate
+                , examItem.testTime
+                , examItem.year))
+                .from(examItem)
+                .where(examItem.schoolLevel.eq(SchoolLV.valueOf(userSL))
+                        .and(examItem.subject.eq(subject))
+                        .and(examItem.round.eq(examKind))
+                        .and(examItem.useYn.eq("Y")))
+                .limit(1)
+                .orderBy(examItem.year.desc())
+                .fetchOne();
+        return dto;
     }
 
 

--- a/src/main/java/com/tive/service/ExamService.java
+++ b/src/main/java/com/tive/service/ExamService.java
@@ -9,4 +9,6 @@ public interface ExamService {
     List<ExamDTO> findExamList();
 
     List<QuestionDTO> findExam(Long eid);
+
+    ExamDTO findExamInfo(String userSL, String subject, int examKind);
 }

--- a/src/main/java/com/tive/service/ExamServiceImpl.java
+++ b/src/main/java/com/tive/service/ExamServiceImpl.java
@@ -24,5 +24,11 @@ public class ExamServiceImpl implements ExamService{
         return exam;
     }
 
+    @Override
+    public ExamDTO findExamInfo(String userSL, String subject, int examKind) {
+        ExamDTO examInfo = examItemRepository.findExamInfo(userSL, subject, examKind);
+        return examInfo;
+    }
+
 
 }

--- a/src/main/resources/static/css/info/cbt_test.css
+++ b/src/main/resources/static/css/info/cbt_test.css
@@ -68,11 +68,13 @@
 .testbtn{
     background-color: #46B1B7;
     border-radius: 30px;
-    color: white;
     font-size: 1.5rem;
     font-weight: bold;
     padding: 10px 15px;
+    color: white;
+    white-space: nowrap;
 }
+
 .cbt_guide a{
     text-decoration: none;
 }

--- a/src/main/resources/templates/info/cbt_test.html
+++ b/src/main/resources/templates/info/cbt_test.html
@@ -23,7 +23,13 @@
                         <li>동영상, 듣기 내용은 <span>한 번만</span> 들려주는 문항이 있습니다. 잘 청취하도록 유의 바랍니다.</li>
                         <li>헤드셋 혹은 이어폰을 착용해 주시기 바랍니다.</li>
                     </ul>
-                    <a th:href="@{/test}"><div class="testbtn">시험시작</div></a>
+                    <div>
+                        <!--초등 CBT 데이터 들어오면 바꿔야 함-->
+                        <a class="testbtn" th:href="@{/test}" target="_blank" th:if="${schoolLevel.equals('EL')}">시험시작</a>
+
+                        <!--중고등 CBT 데이터 없음-->
+                        <a class="testbtn" th:href="@{/exam1/13}" target="_blank" th:if="${!schoolLevel.equals('EL')}">시험시작</a>
+                    </div>
                 </div>
             </div>
         

--- a/src/main/resources/templates/info/play_test.html
+++ b/src/main/resources/templates/info/play_test.html
@@ -26,7 +26,7 @@
 
             </div>
 
-            <a th:href="@{|/warnInfo/${examKind}|}" id="no_problem_btn">이상 없습니다</a>
+            <a th:href="@{|/warnInfo/${eid}|}" id="no_problem_btn">이상 없습니다</a>
 
         </div>
 

--- a/src/main/resources/templates/info/test_gogo.html
+++ b/src/main/resources/templates/info/test_gogo.html
@@ -29,37 +29,37 @@
                         <tr>
                             <td>1교시</td>
                             <td>국어</td>
-                            <td>응시 시각으로부터 40분</td>
-                            <td>24문항</td>
-                            <td><a th:href="@{|/playTest/${examKind}|}">응시하기</a></td>
+                            <td th:text="|응시 시각으로부터 ${korean.testTime}분|"></td>
+                            <td th:text="|${korean.itemCount}문항|"></td>
+                            <td><a th:href="@{|/playTest/${korean.eid}|}">응시하기</a></td>
                         </tr>
                         <tr>
                             <td>2교시</td>
                             <td>영어</td>
-                            <td>응시 시각으로부터 40분</td>
-                            <td>24문항</td>
-                            <td><a th:href="@{|/playTest/${examKind}|}">응시하기</a></td>
+                            <td th:text="|응시 시각으로부터 ${english.testTime}분|"></td>
+                            <td th:text="|${english.itemCount}문항|"></td>
+                            <td><a th:href="@{|/playTest/${english.eid}|}">응시하기</a></td>
                         </tr>
                         <tr>
                             <td>3교시</td>
                             <td>수학</td>
-                            <td>응시 시각으로부터 40분</td>
-                            <td>24문항</td>
-                            <td><a th:href="@{|/playTest/${examKind}|}">응시하기</a></td>
+                            <td th:text="|응시 시각으로부터 ${math.testTime}분|"></td>
+                            <td th:text="|${math.itemCount}문항|"></td>
+                            <td><a th:href="@{|/playTest/${math.eid}|}">응시하기</a></td>
                         </tr>
-                        <tr>
+                        <tr th:if="${userSL!='HL'}">
                             <td>4교시</td>
                             <td>사회</td>
-                            <td>응시 시각으로부터 40분</td>
-                            <td>24문항</td>
-                            <td><a th:href="@{|/playTest/${examKind}|}">응시하기</a></td>
+                            <td th:text="|응시 시각으로부터 ${society.testTime}분|"></td>
+                            <td th:text="|${society.itemCount}문항|"></td>
+                            <td><a th:href="@{|/playTest/${society.eid}|}">응시하기</a></td>
                         </tr>
-                        <tr>
+                        <tr th:if="${userSL!='HL'}">
                             <td>5교시</td>
                             <td>과학</td>
-                            <td>응시 시각으로부터 40분</td>
-                            <td>24문항</td>
-                            <td><a th:href="@{|/playTest/${examKind}|}">응시하기</a></td>
+                            <td th:text="|응시 시각으로부터 ${science.testTime}분|"></td>
+                            <td th:text="|${science.itemCount}문항|"></td>
+                            <td><a th:href="@{|/playTest/${science.eid}|}">응시하기</a></td>
                         </tr>
                     </tbody>
                 </table>

--- a/src/main/resources/templates/info/warn_info.html
+++ b/src/main/resources/templates/info/warn_info.html
@@ -49,7 +49,7 @@
 
             </div>
 
-            <a href="#" id="agree_btn">동의합니다</a>
+            <a th:href="@{|/exam1/${eid}|}" target="_blank" id="agree_btn">동의합니다</a>
 
         </div>
 


### PR DESCRIPTION
1. CBT연습 링크 작업
 - 초등일 경우-> 아직 문제집 데이터 없음
 - 중/고등일 경우 -> 13번 문제 띄움

2. 실전 시험 1,2회
 - 초등, 중등일 경우에는 국영수사과, 고등일 경우에는 국영수만 나오도록 구현
 - 시험 시간표 페이지에서 과목, 회차, 학교급 등 필요한 데이터 받아서 각 과목에 대한  시험시간, 문항수, 시험지 eid 가져옴 (문제집이 2개 있는 경우 최신순 1개를 가져오도록 함)
 - 동영상 및 소리 테스트 화면 부터는 eid만 넘기도록 구현
 - 주의사항 안내 페이지에서 동의합니다 클릭 시 해당 시험지 페이지를 새창으로 띄워주도록 구현

 * 이슈사항
- 초등 CBT 문제집 데이터가 없음 (시험지 테이블에 eid가 없음)
- 중고등 CBT 문제집에 문제가 없음 (null)로 나옴 (eid는 있는데 eid에 해당하는 문제가 없음)
- 비로그인 시 실전시험 메뉴 클릭 시 로그인 창 나오도록 구현해야 함