### PR TITLE
[fix] UsersDTO, header.js 수정, REPORT 화면 템플릿 적용

### DIFF
--- a/src/main/java/com/tive/controller/IndexController.java
+++ b/src/main/java/com/tive/controller/IndexController.java
@@ -35,10 +35,14 @@ public class IndexController {
         //현재 세션으로 유저 이름 가져오기
         String useremail = "";
         String username = "";
+        Long uid=0L;
 
         if (principal != null && principal.getName() != null){ //로그인 한 경우에만 받아옴
             useremail = principal.getName();
+            uid=userService.getUserInfo(useremail).getUid();
             username = userService.getUserInfo(useremail).getName();
+
+            model.addAttribute("uid", uid);
             model.addAttribute("username",username);
         } else { //아니면 로그값 출력
             log.info("Principal is null or principal.getName() is null");

--- a/src/main/java/com/tive/controller/ReportController.java
+++ b/src/main/java/com/tive/controller/ReportController.java
@@ -35,8 +35,8 @@ public class ReportController {
 
         model.addAttribute("report", report);
         model.addAttribute("subject", subject);
-
-        return "report/report_basic";
+        model.addAttribute("view", "report/report_basic");
+        return "index";
     }
 
 
@@ -54,8 +54,8 @@ public class ReportController {
 
         model.addAttribute("report", report);
         model.addAttribute("subject", subject);
-
-        return "report/report_detail";
+        model.addAttribute("view", "report/report_detail");
+        return "index";
     }
 
     /**정오표 - 서답형 미포함 리스트*/

--- a/src/main/java/com/tive/dto/UsersDTO.java
+++ b/src/main/java/com/tive/dto/UsersDTO.java
@@ -9,7 +9,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class UsersDTO {
-    private String uid;
+    private Long uid;
 
     @NotEmpty(message = "입력해")
     private String name;

--- a/src/main/resources/static/js/index/header.js
+++ b/src/main/resources/static/js/index/header.js
@@ -1,43 +1,6 @@
-window.onload = function () {
-
+window.addEventListener('load', function () {
     let navHeader = document.getElementById('nav_header');
-    // let logo = document.getElementById('logo');
     let mainMenu = navHeader.querySelectorAll('.main_menu');
-    // let mainMenuSelectColor = 'transparent';
-    //
-    // function updateNavBar() { //상단 메뉴바 스타일 변경 함수
-    //
-    //     if (window.scrollY >= 0) { //마우스 스크롤로 50px 내리면 상단바 디자인 변경
-    //
-    //         // 흰배경 있는 버전
-    //         logo.src = '/img2/logo2.png'; //로고 변경
-    //         navHeader.style.backgroundColor = 'rgba(255,255,255,0.8)'; //배경 변경
-    //         navHeader.style.boxShadow = '4px 4px 4px rgba(0, 0, 0, 0.1)'; //그림자 추가
-    //         mainMenu.forEach(function(li) {
-    //             li.style.color = 'black'; //글자색 변경
-    //         });
-    //         mainMenuSelectColor = '#5DCCF3';
-    //
-    //     } else { // 스크롤이 50px 위이면
-    //
-    //         // 투명 배경 버전
-    //         logo.src = '/img2/logo1.png';
-    //         navHeader.style.backgroundColor = 'transparent';
-    //         navHeader.style.boxShadow = 'none'; //그림자 빼기
-    //         mainMenu.forEach(function(li) {
-    //             li.style.color = 'white';
-    //         });
-    //         mainMenuSelectColor = 'white';
-    //
-    //     }
-    // }
-
-    // window.addEventListener('scroll', updateNavBar);
-
-    // 페이지가 로드될 때 한 번 호출하여 초기 상태 설정
-    // updateNavBar();
-
-
 
     // 서브메뉴 토글 기능 추가
     mainMenu.forEach(function(menu) {
@@ -104,4 +67,5 @@ window.onload = function () {
     if(document.getElementById('up_arrow')){
         updateSliderBtn();
     }
-}
+})
+

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -33,8 +33,8 @@
                     <li class="main_menu" id="main_menu3">
                         <p>REPORT</p>
                         <ul class="sub_menu" id="sub_menu3" style="display: none">
-                            <li>기본리포트</li>
-                            <li>상세리포트</li>
+                            <li><a th:href="@{|/report_basic/${uid}|}">기본리포트</a></li>
+                            <li><a th:href="@{|/report_detail/${uid}|}">상세리포트</a></li>
                         </ul>
                     </li>
 


### PR DESCRIPTION
1. UsersDTO에 uid가 String 타입으로 되어있어서 Long타입으로 변경

2. window.onload를 중복해서 사용하면 모두 작동하지 않는 현상 발견
 - header.js와 report_basic.js에서 window.onload를 사용하고 있어 헤더 메뉴가 안먹는 현상이 발생
 - 기존 window.onload = 콜백함수 방식으로 작성된 header.js를 window.addEventListener('load', 콜백함수) 방식으로 window.onload를 중복해서 사용할 수 있도록 코드 수정

3. REPORT 화면 템플릿 적용되도록 수정
 - 헤더에서 기본리포트, 상세리포트 클릭 시 해당 페이지로 이동
 - 시험 본 이력이 없는 경우 에러 발생하는데 나중에 따로 처리해야 할 것 같음