### PR TITLE
[feat] 시험 시간표 페이지에 결과보기 버튼 활성화, 지도메뉴 추가

### DIFF
--- a/src/main/resources/static/css/info/test_gogo.css
+++ b/src/main/resources/static/css/info/test_gogo.css
@@ -1,6 +1,6 @@
 #wrap{
     width: 100%;
-    height: 110vh;
+    height: 100vh;
     background-color: #46B1B7;
     position: relative;
     font-family: omyu_pretty;
@@ -10,7 +10,7 @@
     align-content: center;
     text-align: center;
     font-weight: bold;
-    top: 15vh;
+    top: 12vh;
     position: relative;
     background-color: white;
     width: 45vw;
@@ -28,7 +28,7 @@
 }
 
 .gogo_wrap span{
-    font-size: 1.4vw;
+    font-size: 1.3vw;
     color: #757575;
     line-height: 3.5vh;
     font-weight: normal;
@@ -104,4 +104,13 @@ tbody td a {
     color: white;
     font-size: 1.5vw;
     padding: 1vh 1.2vw;
+}
+
+.result_btn:hover{
+    background-color: #5CC7CE;
+}
+
+.result_btn a{
+    text-decoration: none;
+    color: white;
 }

--- a/src/main/resources/templates/info/test_gogo.html
+++ b/src/main/resources/templates/info/test_gogo.html
@@ -93,7 +93,12 @@
                     <div class="test_guide1"><div class="testgo">응시하기</div><p>시험을 응시할 수 있는 상태</p></div>
                     <div class="test_guide1"><div class="retry">재응시</div><p>시험을 재응시 할 수 있는 상태</p></div>
                 </div>
-                <a><div class="result_btn">결과보기</div></a>
+                <th:block th:if="${hasTakenEnglish and hasTakenKorean and hasTakenMath and hasTakenSociety and hasTakenScience}">
+                    <div class="result_btn"><a th:href="@{/report_basic}">결과보기</a></div>
+                </th:block>
+                <th:block th:unless="${hasTakenEnglish and hasTakenKorean and hasTakenMath and hasTakenSociety and hasTakenScience}">
+                    <div class="result_btn"><a id="result_back">결과보기</a></div>
+                </th:block>
             </div>
 
 
@@ -109,4 +114,12 @@
 
     </div>
 </body>
+<script>
+    if(document.getElementById('result_back')){
+      let result_back = document.getElementById('result_back');
+      result_back.addEventListener('click', function () {
+          alert("시험을 모두 응시해 주세요!");
+      })
+    }
+</script>
 </html>


### PR DESCRIPTION
 - 과목 중에 하나라도 시험본 이력이 없다면 리포트 페이지로 못넘어가고, 알림창이 뜸
 - 추후에 report 페이지에서도 이 부분 생각해봐야 할듯
 - 헤더에 지도 메뉴 추가