### PR TITLE
[feat] 지도 구현 중

### DIFF
--- a/src/main/java/com/tive/controller/IndexController.java
+++ b/src/main/java/com/tive/controller/IndexController.java
@@ -204,7 +204,26 @@ public class IndexController {
     }
 
     @GetMapping("/ranking")
-    public String showRank(Model model){
+    public String showRank(
+            Model model
+            , Principal principal){
+
+        //현재 세션으로 유저 이름, 지역 교육청 코드 가져오기
+        String useremail = "";
+        String username = "";
+        int userLC = 0;
+
+        if (principal != null && principal.getName() != null) { //로그인 한 경우에만 받아옴
+            useremail = principal.getName();
+
+            username = userService.getUserInfo(useremail).getName(); // 이름
+            userLC = userService.getUserInfo(useremail).getLocalCode(); // 학교급
+
+            model.addAttribute("username", username);
+            model.addAttribute("userLC", userLC);
+
+        }
+
         List<UsersDTO> rank = reportService.findRanking();
         model.addAttribute("rank",rank);
         model.addAttribute("view", "report/ranking");

--- a/src/main/resources/static/js/report/map.js
+++ b/src/main/resources/static/js/report/map.js
@@ -3,6 +3,9 @@ window.onload = function () {
     var map;
     var markers = []; // 마커들을 담을 배열
 
+    const localCode = document.getElementById('localCode').value; // 시도교육청코드 설정
+    console.log("지역코드: ", localCode);
+
     // Naver Map 초기화
     function loadNaverMap(lat, lng) {
         console.log("네이버 맵 초기화:", lat, lng);
@@ -29,7 +32,6 @@ window.onload = function () {
     }
 
     function fetchData(){
-        const localCode = "7010000"; // 시도교육청코드 설정
 
         fetch(`/schools?localCode=${localCode}`, {
             method: "GET",
@@ -75,9 +77,20 @@ window.onload = function () {
         console.log("[테스트] 마커 추가됨:", marker);
     }
 
-    // 지도 초기화 호출
-    const seoulEduLat = 37.570452;
-    const seoulEduLng = 126.976792;
-    loadNaverMap(seoulEduLat, seoulEduLng);
+    //지도 초기화 호출
+    let EduLat = 0;
+    let EduLng = 0;
+    switch (localCode) {
+        case "7530000": //경기도 교육청일 경우
+            EduLat = 37.2835;
+            EduLng = 127.0467;
+            console.log("경기도 교육청.............")
+            break;
+        default:
+            EduLat = 37.570452;
+            EduLng = 126.976792;
+    }
+
+    loadNaverMap(EduLat, EduLng);
     fetchData();
 }

--- a/src/main/resources/templates/report/ranking.html
+++ b/src/main/resources/templates/report/ranking.html
@@ -32,6 +32,7 @@
                 </div>
 
                 <h1>우리 팀</h1>
+                <input id="localCode" type="hidden" th:value="${userLC}">
                 <div id="map"></div>
             </section>
         </div>


### PR DESCRIPTION
1. 현재 위치 초기화 작업
 - report 페이지로 넘어갈 때 username과 localCode를 넘겨서 헤더메뉴에 로그인한 사용자 정보를 보여주고 localCode에 맞는 위치로 초기화 하도록 구현 (아직 서울, 경기도만 함 - 서울이 디폴트)

 2. 앞으로 해야 할 것
- switch문으로 지역(localCode)별로 초기 위치 초기화
- 학교 로고 수집 후 랭킹 부분 UI 수정